### PR TITLE
DEV-2771 Do not retry when `Transfer.transfer` exception is caused by missing source file (404)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,15 @@ RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup
 WORKDIR /app
 
 # Let the appuser own the files so he can rwx during runtime.
-COPY --chown=appuser:appgroup . .
+COPY . .
+RUN chown -R appuser:appgroup /app
 
 # We install all our Python dependencies. Add the extra index url because some
 # packages are in the meemoo repo.
 RUN pip3 install -r requirements.txt \
-    --extra-index-url http://do-prd-mvn-01.do.viaa.be:8081/repository/pypi-all/simple \
-    --trusted-host do-prd-mvn-01.do.viaa.be
+        --extra-index-url http://do-prd-mvn-01.do.viaa.be:8081/repository/pypi-all/simple \
+        --trusted-host do-prd-mvn-01.do.viaa.be && \
+    pip3 install -r requirements-dev.txt
 
 USER appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup
 WORKDIR /app
 
 # Let the appuser own the files so he can rwx during runtime.
-COPY . .
-RUN chown -R appuser:appgroup /app
+COPY --chown=appuser:appgroup . .
 
 # We install all our Python dependencies. Add the extra index url because some
 # packages are in the meemoo repo.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ There is an optional free space check in which the remote server needs to have a
 - Docker (optional)
 - Python 3.10+
 - Access to the [meemoo PyPi](http://do-prd-mvn-01.do.viaa.be:8081)
-- Poetry
 
 ## Diagrams
 
@@ -44,17 +43,23 @@ There is an optional free space check in which the remote server needs to have a
     You can use `!ENV ${EXAMPLE}` as a config value to make the application get the `EXAMPLE` environment variable.
 
 ### Running locally
+
 1. Install the external modules:
 
-    `$ poetry install`
+    ```
+    $ pip install -r requirements.txt  \
+        --extra-index-url http://do-prd-mvn-01.do.viaa.be:8081/repository/pypi-all/simple \
+        --trusted-host do-prd-mvn-01.do.viaa.be && \
+      pip install -r requirements-dev.txt
+    ```
 
 2. Run the tests (and setting the values in `.env.example` first):
 
-    `$ export $(grep -v '^#' .env.example | xargs -0); poetry run pytest -v --cov=./app`
+    `$ env $(grep -oE '^[^([:space:]*#[:space:]*)]+' .env.example | xargs) python -m pytest -v --cov=./app`
 
 3. Run the application:
 
-    `$ poetry run python main.py`
+    `$ python main.py`
 
 ### Running using Docker
 
@@ -66,6 +71,6 @@ There is an optional free space check in which the remote server needs to have a
 
    `$ docker run --env-file .env.example --rm --entrypoint python s3-transfer-service:latest -m pytest -v --cov=./app`
 
-2. Run the container (with specified `.env` file):
+3. Run the container (with specified `.env` file):
 
    `$ docker run --env-file .env --rm s3-transfer-service:latest`

--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,7 @@ from viaa.configuration import ConfigParser
 from viaa.observability import logging
 
 from app.helpers.message_parser import parse_validate_json, InvalidMessageException
-from app.helpers.transfer import TransferException, Transfer
+from app.helpers.transfer import TransferException, Transfer, TransferSourceFileNotFoundException
 from app.services.rabbit import RabbitClient
 
 
@@ -54,7 +54,7 @@ class EventListener:
         # Start the transfer
         try:
             Transfer(message).transfer()
-        except (TransferException, OSError):
+        except (TransferException, TransferSourceFileNotFoundException, OSError):
             self.log.error("Transfer failed")
             cb_nack = functools.partial(self.nack_message, channel, delivery_tag)
             self.rabbit_client.connection.add_callback_threadsafe(cb_nack)

--- a/app/helpers/transfer.py
+++ b/app/helpers/transfer.py
@@ -114,7 +114,7 @@ class Transfer:
 
         Raises:
             TransferException: If it was not possible to get the size of the file.
-            TransferNotFoundException: If the request returned a 404 status code.
+            TransferSourceFileNotFoundException: If the request returned a 404 status code.
         """
 
         head_response = requests.head(

--- a/app/helpers/transfer.py
+++ b/app/helpers/transfer.py
@@ -21,6 +21,10 @@ class TransferException(Exception):
     pass
 
 
+class TransferSourceFileNotFoundException(Exception):
+    pass
+
+
 def build_curl_command(destination: str, source_url: str, s3_domain: str) -> str:
     """Build the cURL command.
 
@@ -109,15 +113,24 @@ class Transfer:
             The size of the file in bytes.
 
         Raises:
-            TransferException: If it was not possible to get the size of the file,
-                e.g. a 404.
+            TransferException: If it was not possible to get the size of the file.
+            TransferNotFoundException: If the request returned a 404 status code.
         """
 
-        size_in_bytes = requests.head(
+        head_response = requests.head(
             self.source_url,
             allow_redirects=True,
-            headers={"host": self.domain, "Accept-Encoding": "identity"},
-        ).headers.get("content-length", None)
+            headers={
+                "host": self.domain,
+                "Accept-Encoding": "identity"
+            },
+        )
+
+        status = head_response.status_code
+        if status == 404:
+            raise TransferSourceFileNotFoundException
+
+        size_in_bytes = head_response.headers.get("content-length", None)
 
         if not size_in_bytes:
             log.error(
@@ -125,7 +138,7 @@ class Transfer:
             )
             raise TransferException
 
-        return size_in_bytes
+        return int(size_in_bytes)
 
     def _check_free_space(self):
         """Check if there is sufficient free space on the remote server.
@@ -231,36 +244,47 @@ class Transfer:
         try:
             # Execute the cURL command and examine results
             _stdin, stdout, stderr = self.remote_client.exec_command(curl_cmd)
-            results = []
-            out = stdout.readlines()
+
             err = stderr.readlines()
-            if err:
+            if len(err) != 0:
                 log.error(
                     f"Error occurred when cURLing tmp file: {err}",
                     destination=self.dest_file_tmp_full,
                 )
                 raise TransferException
-            if out:
-                try:
-                    results = out[0].split(",")
-                    status_code = results[0]
-                    if int(status_code) >= 400:
-                        log.error(
-                            f"Error occurred when cURLing tmp file with status code: {status_code}",
-                            destination=self.dest_file_tmp_full,
-                        )
-                        raise TransferException
-                    log.info(
-                        "Successfully cURLed tmp file",
-                        destination=self.dest_file_tmp_full,
-                        results=results,
-                    )
-                except IndexError as i_e:
-                    log.error(
-                        f"Error occurred cURLing tmp file: {i_e}",
-                        destination=self.dest_file_tmp_full,
-                    )
-                    raise TransferException
+
+            out = stdout.readlines()
+            try:
+                results = out[0].split(",")
+                status_code = int(results[0])
+            except (IndexError, ValueError):
+                log.error(
+                    "Error occurred when cURLing tmp file: out is empty "
+                    "or has invalid content"
+                )
+                raise TransferException
+
+            if status_code == 404:
+                log.error(
+                    "Error occurred when cURLing tmp file: file not found,"
+                    f" status code: {status_code}"
+                )
+                raise TransferSourceFileNotFoundException
+
+            if status_code >= 400:
+                log.error(
+                    "Error occurred when cURLing tmp file: received status"
+                    f" code: {status_code}",
+                    destination=self.dest_file_tmp_full,
+                )
+                raise TransferException
+
+            log.info(
+                "Successfully cURLed tmp file",
+                destination=self.dest_file_tmp_full,
+                results=results,
+            )
+
         except SSHException as ssh_e:
             log.error(
                 f"SSH Error occurred when cURLing tmp file: {ssh_e}",

--- a/tests/helpers/test_transfer.py
+++ b/tests/helpers/test_transfer.py
@@ -26,12 +26,7 @@ def test_build_curl_command():
 
 
 def has_retries_in_logs(caplog: pytest.LogCaptureFixture) -> bool:
-    return any(
-        map(
-            lambda record: "retrying" in record.message,
-            caplog.records
-        )
-    )
+    return "retrying" in caplog.text
 
 
 class MockChannelFile:
@@ -710,10 +705,10 @@ class TestTransfer:
         transfer,
         caplog: pytest.LogCaptureFixture,
     ):
-        transfer.remote_client.exec_command = lambda _: (
+        transfer.remote_client.exec_command.return_value = (
             MockChannelFile([]),
             MockChannelFile(["404,time: 0.222405s,size: 18373 bytes,speed: 82610b"]),
-            MockChannelFile([])
+            MockChannelFile([]),
         )
 
         with pytest.raises(TransferSourceFileNotFoundException):
@@ -734,10 +729,10 @@ class TestTransfer:
         transfer,
         caplog: pytest.LogCaptureFixture,
     ):
-        transfer.remote_client.exec_command = lambda _: (
+        transfer.remote_client.exec_command.return_value = (
             MockChannelFile([]),
             MockChannelFile(["429,time: 0.222405s,size: 18373 bytes,speed: 82610b"]),
-            MockChannelFile([])
+            MockChannelFile([]),
         )
 
         with pytest.raises(TransferException):

--- a/tests/helpers/test_transfer.py
+++ b/tests/helpers/test_transfer.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from paramiko import SSHException
 
 from app.helpers.transfer import (
+    TransferSourceFileNotFoundException,
     build_curl_command,
     Transfer,
     TransferException,
@@ -22,6 +23,23 @@ def test_build_curl_command():
         curl_command
         == f"curl -w '{w_params}' -L -H 'host: {domain}' -S -s -o '{dest}' '{src}'"
     )
+
+
+def has_retries_in_logs(caplog: pytest.LogCaptureFixture) -> bool:
+    return any(
+        map(
+            lambda record: "retrying" in record.message,
+            caplog.records
+        )
+    )
+
+
+class MockChannelFile:
+    def __init__(self, lines: list[str]):
+        self.lines = lines
+
+    def readlines(self):
+        return [line for line in self.lines]
 
 
 class TestTransfer:
@@ -642,3 +660,87 @@ class TestTransfer:
         )
 
         assert transfer.size_in_bytes == 100
+
+    @patch.object(Transfer, "_init_remote_client")
+    @patch.object(Transfer, "_check_free_space")
+    @patch("requests.head")
+    def test_fetch_size_404_should_not_retry(
+        self,
+        head,
+        _check_free_space_mock,
+        _init_remote_client_mock,
+        transfer,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        head().status_code = 404
+
+        with pytest.raises(TransferSourceFileNotFoundException):
+            transfer.transfer()
+
+        assert not has_retries_in_logs(caplog)
+
+    @patch.object(Transfer, "_init_remote_client")
+    @patch.object(Transfer, "_check_free_space")
+    @patch("requests.head")
+    def test_fetch_size_no_content_length_should_retry(
+        self,
+        head,
+        _check_free_space_mock,
+        _init_remote_client_mock,
+        transfer,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        head().headers = {}
+
+        with pytest.raises(TransferException):
+            transfer.transfer()
+
+        assert has_retries_in_logs(caplog)
+
+    @patch.object(Transfer, "_init_remote_client")
+    @patch.object(Transfer, "_check_free_space")
+    @patch.object(Transfer, "_fetch_size")
+    @patch.object(Transfer, "_prepare_target_transfer")
+    def test_curl_404_should_not_retry(
+        self,
+        _prepare_target_transfer_mock,
+        _fetch_size_mock,
+        _check_free_space_mock,
+        _init_remote_client_mock,
+        transfer,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        transfer.remote_client.exec_command = lambda _: (
+            MockChannelFile([]),
+            MockChannelFile(["404,time: 0.222405s,size: 18373 bytes,speed: 82610b"]),
+            MockChannelFile([])
+        )
+
+        with pytest.raises(TransferSourceFileNotFoundException):
+            transfer.transfer()
+
+        assert not has_retries_in_logs(caplog)
+
+    @patch.object(Transfer, "_init_remote_client")
+    @patch.object(Transfer, "_check_free_space")
+    @patch.object(Transfer, "_fetch_size")
+    @patch.object(Transfer, "_prepare_target_transfer")
+    def test_curl_429_should_retry(
+        self,
+        _prepare_target_transfer_mock,
+        _fetch_size_mock,
+        _check_free_space_mock,
+        _init_remote_client_mock,
+        transfer,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        transfer.remote_client.exec_command = lambda _: (
+            MockChannelFile([]),
+            MockChannelFile(["429,time: 0.222405s,size: 18373 bytes,speed: 82610b"]),
+            MockChannelFile([])
+        )
+
+        with pytest.raises(TransferException):
+            transfer.transfer()
+
+        assert has_retries_in_logs(caplog)

--- a/tests/helpers/test_transfer.py
+++ b/tests/helpers/test_transfer.py
@@ -39,7 +39,7 @@ class MockChannelFile:
         self.lines = lines
 
     def readlines(self):
-        return [line for line in self.lines]
+        return self.lines.copy()
 
 
 class TestTransfer:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from app.helpers.message_parser import InvalidMessageException
+from app.helpers.transfer import Transfer, TransferSourceFileNotFoundException
 from app.app import EventListener
 
 
@@ -23,3 +24,14 @@ def test_do_work_invalid_message(transfer_mock, parse_mock, event_listener, capl
     rabbit_client_mock = event_listener.rabbit_client
     assert rabbit_client_mock.connection.add_callback_threadsafe.call_count == 1
     assert not transfer_mock.call_count
+
+
+@patch("app.app.parse_validate_json")
+@patch.object(Transfer, "transfer", side_effect=TransferSourceFileNotFoundException)
+def test_transfer_source_file_not_found_exception_does_not_crash_app(
+    transfer_mock,
+    parse_validate_json_mock,
+    event_listener,
+    caplog
+):
+    event_listener.do_work(None, None, None)


### PR DESCRIPTION
Currently the `Transfer.transfer` function automatically retries 3 times when a `TransferException` is raised. This behaviour is not desirable when the cause of the exception can not possibly be resolved by retrying the function. One such case is a 404 error indicating a missing file.

As regards the `Transfer.transfer` function, the `TransferException` can be raised in the following places:

- `_fetch_size` (lines 126)
- `_prepare_target_transfer` (line 219)
- `_transfer_file` (lines 242, 252, 263, 269, 281, 287, 301, 312, 321)

| function | line | change | note |
| -------- | ---- | ------ | ---- |
| `_fetch_size`  | 126 | Y | Pertains to a possible 404 error |
| `_prepare_target_transfer` | 219 | N | General SSH error |
| `_transfer_file` | 242 | N | Checks curl stderr and should does not imply a 404 error |
| `_transfer_file` | 252 | Y | Relates to a possible 404 from curl |
| `_transfer_file` | 263 | N | Pertains to an IndexError, can be refactored out |
| `_transfer_file` | 269 | N | General SSH error |
| `_transfer_file` | 281 | N | General size mismatch error |
| `_transfer_file` | 287 | N | General OSError |
| `_transfer_file` | 301 | N | General OSError |
| `_transfer_file` | 312 | N | General SSH error |
| `_transfer_file` | 321 | N | General OSError |

> Some further explanation regarding the two cases where a code change is necessary:
>
> `_fetch_size` line 126: Here a HEAD request is sent to the source file, defined by a source url, which could possibly return a 404. In that case, there is no file to be transferred and we should not retry.
>
> `_transfer_file` line 252: Here we notice that our cURL command, which attempted to download the source file, returns a 404. As in the previous case, this implies that there is no file to be transferred and we should not retry.

A small refactor of the `_transfer_file` function has been done as well to make the logic more legible and reduce nesting.

As the documentation was outdated, I have pushed a commit to ensure that the `README` setup and testing documentation are correct. I have also updated the `Dockerfile` so that the user has correct permissions for the workdir so tests work in the service's Docker container.

> **NOTE**: There are probably a range of other status codes that can be used as a heuristic to decide whether to retry or not. Intuitively I assumed this would be true for all 4xx client errors, but @spacid reminded me that 429 can actually be resolved using a retry (though whether our retry method is appropriate in this case, is unclear).